### PR TITLE
Fix TypeError: undefined is not a function in RN 0.65.1

### DIFF
--- a/src/api.tsx
+++ b/src/api.tsx
@@ -30,10 +30,12 @@ export const scrollIntoView = async (
     align,
   );
 
-  scrollView
-    .getScrollResponder()
-    // @ts-ignore
-    .scrollResponderScrollTo({ x: 0, y: newScrollY, animated });
+  const scrollResponder = scrollView.getScrollResponder();
+  if (scrollResponder.scrollResponderScrollTo != null) {
+    scrollResponder.scrollResponderScrollTo({ x: 0, y: newScrollY, animated });
+  } else {
+    scrollView.scrollTo({ x: 0, y: newScrollY, animated });
+  }
 };
 
 type GetScrollView = () => ScrollView;


### PR DESCRIPTION
`scrollResponderScrollTo` no longer exists on ScrollResponder in RN 0.65.1, leading to a `TypeError: undefined is not a function` when calling `scrollIntoView`.
This commit fixes this issue by calling `scrollView.scrollTo` instead when `scrollResponderScrollTo` does not exist.